### PR TITLE
When getting record ID, select only A records and refresh on every interval

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -13,15 +13,16 @@ test -z $DOMAIN && die "DOMAIN not set!"
 test -z $NAME && die "NAME not set!"
 
 dns_list="$api_host/domains/$DOMAIN/records"
-domain_records=$(curl -s -X GET \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    $dns_list)
-record_id=$(echo $domain_records| jq ".domain_records[] | select(.name == \"$NAME\") | .id")
-
-test -z $record_id && die "No record found with given domain name!"
 
 while ( true ); do
+    domain_records=$(curl -s -X GET \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+        $dns_list)
+    record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .id")
+    
+    test -z $record_id && die "No record found with given domain name!"
+
     ip="$(curl -s ipinfo.io/ip)"
     data="{\"type\": \"A\", \"name\": \"$NAME\", \"data\": \"$ip\"}"
     url="$dns_list/$record_id"


### PR DESCRIPTION
In my use case, I have several record types (A and MX) for $NAME, which caused $record_id to be set to multiple values. This pull request updates the jq filter to ensure the selected record is an A record.

I also plan to run this unattended for long periods of time, so I'd like to avoid needing to remember to restart it if the record ID changes (e.g. if I manually delete and recreate it for some reason).