### PR TITLE
Check IP of subdomain rather than domain

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -20,7 +20,7 @@ while ( true ); do
         -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
         $dns_list)
     record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .id")
-    record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"@\") | .data")
+    record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .data")
     
     test -z $record_id && die "No record found with given domain name!"
 


### PR DESCRIPTION
Right now the IP address that the script gets to compare the current IP address against is the `@` record rather than the subdomain record. If the subdomain IP is different from the domain IP, this will always trigger an update.