### PR TITLE
Add pagination link to get full list

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -13,12 +13,13 @@ test -z $DOMAIN && die "DOMAIN not set!"
 test -z $NAME && die "NAME not set!"
 
 dns_list="$api_host/domains/$DOMAIN/records"
+dns_list_long="$api_host/domains/$DOMAIN/records?per_page=200"
 
 while ( true ); do
     domain_records=$(curl -s -X GET \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-        $dns_list)
+        $dns_list_long)
     record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .id")
     record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .data")
     


### PR DESCRIPTION
Workaround for big zones. By default, only 20 objects are returned per page. 

You can request a different pagination limit or force pagination by appending ?per_page= to the request with the number of items you would like per page. For instance, to show only two results per page, you could add ?per_page=2 to the end of your query. The maximum number of results per page is 200.

https://developers.digitalocean.com/documentation/v2/#links