### PR TITLE
Add support for multiple subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pick one of the options below using the following settings:
 
 * **DIGITALOCEAN_TOKEN:** The token you generate in DigitalOcean's API settings.
 * **DOMAIN:** The domain your subdomain is registered at. (i.e. `foo.com` for `home.foo.com`)
-* **NAME:** Subdomain to use. (name in A record) (i.e. `home` for `home.foo.com`)
+* **NAME:** Subdomain to use. (name in A record) (i.e. `home` for `home.foo.com`). Multiple subdomains must be separated by semicolons `;`
 * **SLEEP_INTERVAL:** Polling time in seconds. (default: 300)
 
 ### Docker (Recommended)

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -19,25 +19,29 @@ while ( true ); do
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
         $dns_list)
-    record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .id")
-    record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$NAME\") | .data")
-    
-    test -z $record_id && die "No record found with given domain name!"
 
     ip="$(curl -s ipinfo.io/ip)"
-    data="{\"type\": \"A\", \"name\": \"$NAME\", \"data\": \"$ip\"}"
-    url="$dns_list/$record_id"
 
     if [[ -n $ip ]]; then
-        if [[ "$ip" != "$record_data" ]]; then
-            echo "existing DNS record address ($record_data) doesn't match current IP ($ip), sending data=$data to url=$url"
+        for sub in ${NAME//;/ }; do
+            record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .id")
+            record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .data")
+            
+            test -z $record_id && echo "No record found with '$sub' domain name!" && continue
 
-            curl -s -X PUT \
-                -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-                -d "$data" \
-                "$url" &> /dev/null
-        fi
+            if [[ "$ip" != "$record_data" ]]; then
+                data="{\"type\": \"A\", \"name\": \"$sub\", \"data\": \"$ip\"}"
+                url="$dns_list/$record_id"
+
+                echo "existing DNS record address ($record_data) doesn't match current IP ($ip), sending data=$data to url=$url"
+
+                curl -s -X PUT \
+                    -H "Content-Type: application/json" \
+                    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+                    -d "$data" \
+                    "$url" &> /dev/null
+            fi
+        done
     else
         echo "IP wasn't retrieved within allowed interval. Will try $sleep_interval seconds later.."
     fi


### PR DESCRIPTION
I wanted to update IP for multiple subdomains, now it's possible to specify them all at once instead of creating multiple docker containers.

Just added a loop `for sub in ${NAME//;/ }; do` and reordered some lines. Should be 100% backward-compatible.