### PR TITLE
Replace ipinfo.io with ifconfig.me

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -20,7 +20,7 @@ while ( true ); do
         -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
         $dns_list"?per_page=200")
 
-    ip="$(curl -s ipinfo.io/ip)"
+    ip="$(curl -s ifconfig.me)"
 
     if [[ -n $ip ]]; then
         for sub in ${NAME//;/ }; do

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -20,7 +20,8 @@ while ( true ); do
         -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
         $dns_list"?per_page=200")
 
-    ip="$(curl -s ifconfig.me)"
+    ip="$(curl -s ipinfo.io/ip)"
+    if [[ -z $ip ]]; then ip=$(curl -s ifconfig.me); fi
 
     if [[ -n $ip ]]; then
         for sub in ${NAME//;/ }; do


### PR DESCRIPTION
I just set this up on a new computer and saw that the IP field was empty at all times.
Turns out ipinfo.io is no longer available, so I replaced it with ifconfig.me.