### PR TITLE
disable filename expansion during evalutation of the NAME env variable

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -36,10 +36,15 @@ while ( true ); do
     echo "Found IP address $ip"
 
     if [[ -n $ip ]]; then
+		# disable glob expansion
+		set -f
         for sub in ${NAME//;/ }; do
             record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .id")
             record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .data")
             
+			# re-enalbe glob expansion
+			set +f
+
             test -z $record_id && echo "No record found with '$sub' domain name!" && continue
 
             if [[ "$ip" != "$record_data" ]]; then

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -36,14 +36,15 @@ while ( true ); do
     echo "Found IP address $ip"
 
     if [[ -n $ip ]]; then
-		# disable glob expansion
-		set -f
+        # disable glob expansion
+        set -f
+		
         for sub in ${NAME//;/ }; do
             record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .id")
             record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .data")
             
-			# re-enalbe glob expansion
-			set +f
+            # re-enable glob expansion
+            set +f
 
             test -z $record_id && echo "No record found with '$sub' domain name!" && continue
 


### PR DESCRIPTION
This makes it possible to update wildcard records which contain an asteriks (*) as subdomain name.
The NAME variable could look something like:
```
$ docker run -d --name dyndns \
    -e DIGITALOCEAN_TOKEN="your_token_here" \
    -e DOMAIN="yourdomain.com" \
    -e NAME="@;*" \
    tunix/digitalocean-dyndns
```
With filename expansion on this would lead to a loop over all filenames in the directory.