### PR TITLE
Support passing token in DIGITALOCEAN_TOKEN_FILE

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -14,6 +14,7 @@ die() {
     exit 1
 }
 
+test -f "$DIGITALOCEAN_TOKEN_FILE" && DIGITALOCEAN_TOKEN="$(cat $DIGITALOCEAN_TOKEN_FILE)"
 test -z $DIGITALOCEAN_TOKEN && die "DIGITALOCEAN_TOKEN not set!"
 test -z $DOMAIN && die "DOMAIN not set!"
 test -z $NAME && die "NAME not set!"


### PR DESCRIPTION
This enables passing the token with docker secrets, e.g. DIGITALOCEAN_TOKEN_FILE=/run/secrets/do_auth_token