### PR TITLE
Fix breakage when there are multiple DNS records for a single subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Pick one of the options below using the following settings:
 * **DOMAIN:** The domain your subdomain is registered at. (i.e. `foo.com` for `home.foo.com`)
 * **NAME:** Subdomain to use. (name in A record) (i.e. `home` for `home.foo.com`). Multiple subdomains must be separated by semicolons `;`
 * **SLEEP_INTERVAL:** Polling time in seconds. (default: 300)
+* **REMOVE_DUPLICATES:** If set to `"true"`, removes extra DNS records if more than one A record is found on a subdomain. *Note that if this is not enabled, the script will NOT update subdomains with more than one A record* (default: false)
 
 ### Docker (Recommended)
 
@@ -26,6 +27,7 @@ $ docker run -d --name dyndns \
     -e DOMAIN="yourdomain.com" \
     -e NAME="subdomain" \
     -e SLEEP_INTERVAL=2 \
+    -e REMOVE_DUPLICATES="true" \
     tunix/digitalocean-dyndns
 ```
 

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -61,6 +61,7 @@ while ( true ); do
               else :
                   echo "Unable to update '$sub' domain name as it has duplicate DNS records. Set REMOVE_DUPLICATES='true' to remove them."
                   continue
+              fi
             fi
 
             # re-enable glob expansion

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -46,22 +46,22 @@ while ( true ); do
             record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .data")
 
             if [ $(echo "$record_id" | wc -l) -ge 2 ]; then :
-              if [[ "${remove_duplicates}" == "true" ]]; then :
-                  echo "'$sub' domain name has duplicate DNS records, removing duplicates"
-                  record_id_to_delete=$(echo "$record_id"| tail -n +2)
-                  record_id=$(echo "$record_id"| head -1)
-                  record_data=$(echo "$record_data"| head -1)
+                if [[ "${remove_duplicates}" == "true" ]]; then :
+                    echo "'$sub' domain name has duplicate DNS records, removing duplicates"
+                    record_id_to_delete=$(echo "$record_id"| tail -n +2)
+                    record_id=$(echo "$record_id"| head -1)
+                    record_data=$(echo "$record_data"| head -1)
 
-                  while IFS= read -r line; do
-                      curl -s -X DELETE \
-                          -H "Content-Type: application/json" \
-                          -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-                          "$dns_list/$line" &> /dev/null
-                  done <<< "$record_id_to_delete"
-              else :
-                  echo "Unable to update '$sub' domain name as it has duplicate DNS records. Set REMOVE_DUPLICATES='true' to remove them."
-                  continue
-              fi
+                    while IFS= read -r line; do
+                        curl -s -X DELETE \
+                            -H "Content-Type: application/json" \
+                            -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+                            "$dns_list/$line" &> /dev/null
+                    done <<< "$record_id_to_delete"
+                else :
+                    echo "Unable to update '$sub' domain name as it has duplicate DNS records. Set REMOVE_DUPLICATES='true' to remove them."
+                    continue
+                fi
             fi
 
             # re-enable glob expansion

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -33,20 +33,35 @@ while ( true ); do
         ip="$(curl -s $service | grep '[0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\{3\}')"
         test -n "$ip" && break
     done
-    
+
     echo "Found IP address $ip"
 
     if [[ -n $ip ]]; then
         # disable glob expansion
         set -f
-		
+
         for sub in ${NAME//;/ }; do
             record_id=$(echo $domain_records| jq ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .id")
             record_data=$(echo $domain_records| jq -r ".domain_records[] | select(.type == \"A\" and .name == \"$sub\") | .data")
-            
+
+            if [ $(echo "$record_id" | wc -l) -ge 2 ]; then :
+                echo "'$sub' domain name has duplicate DNS records, removing duplicates"
+                record_id_to_delete=$(echo "$record_id"| tail -n +1)
+                record_id=$(echo "$record_id"| head -1)
+                record_data=$(echo "$record_data"| head -1)
+                echo "record_id_to_delete = $record_id_to_delete record_id = $record_id record_data = $record_data"
+
+                while IFS= read -r line; do
+                    curl -s -X DELETE \
+                        -H "Content-Type: application/json" \
+                        -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+                        "$dns_list/$line" &> /dev/null
+                done <<< "$record_id_to_delete"
+            fi
+
             # re-enable glob expansion
             set +f
-            
+
             data="{\"type\": \"A\", \"name\": \"$sub\", \"data\": \"$ip\"}"
             url="$dns_list/$record_id"
 


### PR DESCRIPTION
Previously, the script would fail to update the DNS for a subdomain if there were multiple existing records. With this PR, the script will check for duplicate records and automatically delete all but one of them. 